### PR TITLE
Fix macro hygeine

### DIFF
--- a/src/BenchmarkHistograms.jl
+++ b/src/BenchmarkHistograms.jl
@@ -60,9 +60,9 @@ function Base.show(io::IO, ::MIME"text/plain", bp::BenchmarkHistogram; nbins=NBI
 end
 
 macro benchmark(exprs...)
-    return quote
-        BenchmarkHistogram(BenchmarkTools.@benchmark($(exprs...)))
-    end
+    quote
+        $BenchmarkHistogram($BenchmarkTools.@benchmark($(exprs...)))
+    end |> esc
 end
 
 # We vendor some pretty-printing methods from BenchmarkTools


### PR DESCRIPTION
Fixes #8.
```julia
julia> using BenchmarkHistograms

julia> f(x) = x+1
f (generic function with 1 method)

julia> y=10
10

julia> @benchmark f($y)
samples: 10000; evals/sample: 1000; memory estimate: 0 bytes; allocs estimate: 0
                   ┌                                        ┐ 
      [0.01, 0.02) ┤ 1                                        
      [0.02, 0.03) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 5930   
      [0.03, 0.04) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 4061              
      [0.04, 0.05) ┤ 7                                        
      [0.05, 0.06) ┤ 0                                        
   ns [0.06, 0.07) ┤ 0                                        
      [0.07, 0.08) ┤ 0                                        
      [0.08, 0.09) ┤ 0                                        
      [0.09, 0.1 ) ┤ 0                                        
      [0.1 , 0.11) ┤ 0                                        
      [0.11, 0.12) ┤ 1                                        
                   └                                        ┘ 
                                    Counts
min: 0.019 ns (0.00% GC); mean: 0.024 ns (0.00% GC); median: 0.020 ns (0.00% GC); max: 0.110 ns (0.00% GC).
```

For some reason, I couldn't get it to work by simply escaping the inputs, so instead I escaped the whole expression but interpolated the macro and the `BenchmarkHistogram` constructor. 